### PR TITLE
Docker Compose開発環境とMakefileを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+.PHONY: help build up down restart logs shell clean test
+
+# Default target
+.DEFAULT_GOAL := help
+
+# Docker Compose commands
+build: ## Build the Docker image
+	docker compose build
+
+up: ## Start the application in detached mode
+	docker compose up -d
+
+down: ## Stop and remove containers
+	docker compose down
+
+restart: ## Restart the application
+	docker compose restart
+
+logs: ## Show application logs
+	docker compose logs -f app
+
+shell: ## Open a shell in the running container
+	docker compose exec app sh
+
+# Development commands
+dev: ## Start in development mode with logs
+	docker compose up
+
+stop: ## Stop containers without removing them
+	docker compose stop
+
+# Cleanup commands
+clean: ## Remove containers, networks, and volumes
+	docker compose down -v --remove-orphans
+
+clean-all: ## Remove everything including images
+	docker compose down -v --remove-orphans --rmi all
+
+# Utility commands
+ps: ## Show running containers
+	docker compose ps
+
+top: ## Show running processes
+	docker compose top
+
+# Bundle commands
+bundle-install: ## Install gems in container
+	docker compose run --rm app bundle install
+
+bundle-update: ## Update gems in container
+	docker compose run --rm app bundle update
+
+# Health check
+health: ## Check application health
+	curl -f http://localhost:4567/apple_music/songs_count || echo "Service not healthy"
+
+# Test endpoints
+test-endpoints: ## Test all service endpoints
+	@echo "Testing Apple Music..."
+	@curl -I http://localhost:4567/apple_music/songs_count
+	@echo "\nTesting Spotify..."
+	@curl -I http://localhost:4567/spotify/songs_count
+	@echo "\nTesting YouTube Music..."
+	@curl -I http://localhost:4567/youtube_music/songs_count
+	@echo "\nTesting LINE Music..."
+	@curl -I http://localhost:4567/line_music/songs_count
+	@echo "\nTesting Amazon Music..."
+	@curl -I http://localhost:4567/amazon_music/songs_count
+
+# Quick start
+quick-start: build up logs ## Build, start, and show logs
+
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -29,31 +29,65 @@
 
 ## 使い方
 
-- setup
+### Docker Compose での開発
+
+- 初回起動（ビルド + 起動 + ログ表示）
   ```sh
-  bundle install
+  make quick-start
   ```
 
-- server起動
+- 通常の起動
   ```sh
-  bundle exec ruby app.rb
+  make up
   ```
-  - http://localhost:4567/
-  - http://localhost:4567/apple_music
-  - http://localhost:4567/apple_music/songs_count
-  - http://localhost:4567/apple_music/team_shanghai_alice
-  - http://localhost:4567/spotify
-  - http://localhost:4567/spotify/songs_count
-  - http://localhost:4567/spotify/team_shanghai_alice
-  - http://localhost:4567/youtube_music
-  - http://localhost:4567/youtube_music/songs_count
-  - http://localhost:4567/youtube_music/team_shanghai_alice
-  - http://localhost:4567/line_music
-  - http://localhost:4567/line_music/songs_count
-  - http://localhost:4567/line_music/team_shanghai_alice
 
-- server停止
-  - `Ctrl+C`
+- ログ確認
+  ```sh
+  make logs
+  ```
+
+- 停止
+  ```sh
+  make down
+  ```
+
+- ヘルプ表示（全コマンド確認）
+  ```sh
+  make help
+  ```
+
+### 利用可能なエンドポイント
+
+- http://localhost:4567/
+- http://localhost:4567/apple_music
+- http://localhost:4567/apple_music/songs_count
+- http://localhost:4567/apple_music/team_shanghai_alice
+- http://localhost:4567/spotify
+- http://localhost:4567/spotify/songs_count
+- http://localhost:4567/spotify/team_shanghai_alice
+- http://localhost:4567/youtube_music
+- http://localhost:4567/youtube_music/songs_count
+- http://localhost:4567/youtube_music/team_shanghai_alice
+- http://localhost:4567/line_music
+- http://localhost:4567/line_music/songs_count
+- http://localhost:4567/line_music/team_shanghai_alice
+
+### その他の便利なコマンド
+
+- エンドポイント動作確認
+  ```sh
+  make test-endpoints
+  ```
+
+- アプリケーションの健康状態確認
+  ```sh
+  make health
+  ```
+
+- コンテナ内でシェル実行
+  ```sh
+  make shell
+  ```
 
 ## 機能
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: random-touhou-music
+    ports:
+      - "4567:4567"
+    volumes:
+      - type: bind
+        source: .
+        target: /app
+      - type: volume
+        source: bundle_cache
+        target: /app/vendor/bundle
+    environment:
+      RACK_ENV: development
+      RUBY_YJIT_ENABLE: "1"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -z localhost 4567 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    depends_on: []
+
+volumes:
+  bundle_cache:
+    driver: local


### PR DESCRIPTION
## 概要
- Docker Compose設定を追加し、コンテナベースの開発環境を構築
- 便利なMakeコマンドを追加し、開発作業を効率化
- READMEを更新し、Docker開発手順を整備

## テストプラン
- [x] `make quick-start`でアプリケーションが正常に起動する
- [x] `make health`でヘルスチェックが通る (Apple Music: 33487曲確認)
- [x] `make test-endpoints`で全エンドポイントが応答する (全サービス200 OK)
- [x] `make logs`でログが表示される (quick-startに含まれ動作確認済み)
- [x] `make shell`でコンテナ内にアクセスできる