### PR TITLE
RuboCopを開発環境でのみインストールするように修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,15 @@ COPY . /app
 
 ENV RUBY_YJIT_ENABLE=1
 
-RUN bundle install
+# Accept build argument for environment
+ARG RACK_ENV=production
+
+# Install gems based on environment
+RUN if [ "$RACK_ENV" = "development" ]; then \
+      bundle install; \
+    else \
+      bundle install --without development; \
+    fi
 
 EXPOSE 4567
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        RACK_ENV: development
     container_name: random-touhou-music
     ports:
       - "4567:4567"


### PR DESCRIPTION
## Summary
- 本番環境でRuboCopが不要なため、開発環境でのみインストールするように修正
- Docker環境での条件付きbundle installを実装

## Changes
- Dockerfileで環境変数による条件付きbundle installを実装
- 開発環境(RACK_ENV=development)では全てのgemをインストール
- 本番環境では--without developmentでRuboCopを除外
- docker-compose.ymlでビルド時のRACK_ENV引数を設定

## Test plan
- [x] 開発環境でRuboCopが使用可能なことを確認
- [x] 本番環境でRuboCopが除外されることを確認
- [x] make rubocop コマンドが開発環境で正常動作することを確認